### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Licensed under either of <a href="LICENSE-APACHE">Apache License, Version
 
 <sub>
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Serde by you, as defined in the Apache-2.0 license, shall be
+for inclusion in Obake by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 </sub>
 


### PR DESCRIPTION
Seems like the footer was copy/pasted from serde without adjusting the name