### PR TITLE
silence clippy lint for generated enum

### DIFF
--- a/obake_macros/src/expand.rs
+++ b/obake_macros/src/expand.rs
@@ -328,6 +328,7 @@ impl VersionedItem {
         quote! {
             #[doc(hidden)]
             #(#derives)*
+            #[allow(clippy::enum_variant_names)]
             #vis enum #enum_ident {
                 #(
                     #[allow(non_camel_case_types)]


### PR DESCRIPTION
hi, this is a pretty nice crate :)

clippy is warning about the generated enum variant names once a struct has three or more versions. this pr is just silencing clippy at the respective place, it would be awesome to get a new release with this addition!
