### PR TITLE
fix: Use concrete Versioned type in From impl

### DIFF
--- a/obake_macros/src/expand.rs
+++ b/obake_macros/src/expand.rs
@@ -261,6 +261,7 @@ impl VersionedItem {
                 quote!(#enum_token #ident #variants)
             }
         };
+        let versioned_ident = self.versioned_ident();
 
         Ok(quote! {
             #[doc(hidden)]
@@ -288,10 +289,10 @@ impl VersionedItem {
             }
 
             #[automatically_derived]
-            impl ::core::convert::From<#ident> for ::obake::AnyVersion<#current> {
+            impl ::core::convert::From<#ident> for #versioned_ident {
                 #[inline]
-                fn from(from: #ident) -> ::obake::AnyVersion<#current> {
-                    ::obake::AnyVersion::<#current>::#ident(from)
+                fn from(from: #ident) -> #versioned_ident {
+                    #versioned_ident::#ident(from)
                 }
             }
         })


### PR DESCRIPTION
Changes the `From` impl to use the `Versioned` type rather than the associated type (through `obake::AnyVersion`). This shouldn't change anything functionally but fixes an issue we were seeing where the obake `impl From<foo::Foo_v0_1_0> for <foo::Foo_v0_1_0 as obake::Versioned>::Versioned` impl was conflicting with other generic impls.

You can see a small reproducible example of this issue here: https://github.com/goodSyntax808/obake-example-issue which gives the following error when trying to compile:

```
error[E0119]: conflicting implementations of trait `std::convert::From<foo::Foo_v0_1_0>` for type `Batz`
  --> bar\src\lib.rs:7:1
   |
7  | / impl<T> From<T> for Batz
8  | | where
9  | |     T: Into<Cow<'static, str>>,
10 | | {
...  |
13 | |     }
14 | | }
   | |_^
   |
   = note: conflicting implementation in crate `foo`:
           - impl From<foo::Foo_v0_1_0> for <foo::Foo_v0_1_0 as obake::Versioned>::Versioned;
```

I believe this occurs because
`impl From<foo::Foo_v0_1_0> for <foo::Foo_v0_1_0 as obake::Versioned>::Versioned` can _technically_ be the same as `impl<T> From<T> for Batz` if `<foo::Foo_v0_1_0 as obake::Versioned>::Versioned` implemented `Into<Cow<'static, str>>`. Using the actual type, rather than the associated type, helps avoid this problem.